### PR TITLE
Uses a globally defined database for querying

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.corwur</groupId>
     <artifactId>cytoscape-neo4j-plugin</artifactId>
-    <version>0.4</version>
+    <version>0.5</version>
     <name>Cytoscape Neo4j Plugin</name>
 
     <properties>
@@ -17,7 +17,7 @@
         <cytoscape.version>3.8.0</cytoscape.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.osgi.core.version>6.0.0</org.osgi.core.version>
-        <neo4j-java-driver.version>4.0.2</neo4j-java-driver.version>
+        <neo4j-java-driver.version>4.4.1</neo4j-java-driver.version>
         <junit.version>4.13.1</junit.version>
         <log4j.version>1.2.17</log4j.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/src/main/java/nl/corwur/cytoscape/neo4j/internal/configuration/AppConfiguration.java
+++ b/src/main/java/nl/corwur/cytoscape/neo4j/internal/configuration/AppConfiguration.java
@@ -20,6 +20,7 @@ public class AppConfiguration {
     private static final String TEMPLATEDIR = "templatedir";
     private static final String NEO4J_HOST = "neo4j.host";
     private static final String NEO4J_USERNAME = "neo4j.username";
+    private static final String NEO4J_DATABASE = "neo4j.database";
     private Properties properties = new Properties();
 
     public String getTemplateDirectory() {
@@ -33,6 +34,8 @@ public class AppConfiguration {
     public String getNeo4jUsername() {
         return properties.getProperty(NEO4J_USERNAME);
     }
+
+    public String getNeo4jDatabase() { return properties.getProperty(NEO4J_DATABASE); }
 
     public void setTemplateDirectory(String templateDir) {
         properties.setProperty(TEMPLATEDIR, templateDir);
@@ -55,6 +58,7 @@ public class AppConfiguration {
     private void setDefaultProperties() {
         properties.setProperty(NEO4J_HOST, "localhost");
         properties.setProperty(NEO4J_USERNAME, "neo4j");
+        properties.setProperty(NEO4J_DATABASE, "neo4j");
         properties.setProperty(TEMPLATEDIR, "");
     }
 
@@ -72,8 +76,11 @@ public class AppConfiguration {
         return Paths.get(tmpDir, "corwur-cyneo4j.properties");
     }
 
-    public void setConnectionParameters(String hostname, String username) {
+    public void setConnectionParameters(String hostname, String username, String database) {
         properties.setProperty(NEO4J_HOST, hostname);
         properties.setProperty(NEO4J_USERNAME, username);
+        properties.setProperty(NEO4J_DATABASE, database);
     }
+
+
 }

--- a/src/main/java/nl/corwur/cytoscape/neo4j/internal/neo4j/ConnectionParameter.java
+++ b/src/main/java/nl/corwur/cytoscape/neo4j/internal/neo4j/ConnectionParameter.java
@@ -4,15 +4,17 @@ public class ConnectionParameter {
     private final String host;
     private final String username;
     private final char[] password;
+    private final String database;
 
-    public ConnectionParameter(String url, String username, char[] password) {
+    public ConnectionParameter(String url, String username, char[] password, String database) {
         this.host = url;
         this.username = username;
         this.password = password;
+        this.database = database;
     }
 
     String getBoltUrl() {
-        return "bolt://" + host;
+        return "neo4j://" + host;
     }
 
     String getUsername() {
@@ -21,5 +23,9 @@ public class ConnectionParameter {
 
     String getPasswordAsString() {
         return new String(password);
+    }
+
+    public String getDatabase() {
+        return database;
     }
 }

--- a/src/main/java/nl/corwur/cytoscape/neo4j/internal/neo4j/Neo4jClient.java
+++ b/src/main/java/nl/corwur/cytoscape/neo4j/internal/neo4j/Neo4jClient.java
@@ -4,12 +4,7 @@ import nl.corwur.cytoscape.neo4j.internal.graph.Graph;
 
 import java.util.List;
 
-import org.neo4j.driver.AuthTokens;
-import org.neo4j.driver.Driver;
-import org.neo4j.driver.GraphDatabase;
-import org.neo4j.driver.Record;
-import org.neo4j.driver.Session;
-import org.neo4j.driver.Result;
+import org.neo4j.driver.*;
 import org.neo4j.driver.exceptions.AuthenticationException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 
@@ -18,6 +13,7 @@ public class Neo4jClient {
 
     private Driver driver;
     private Neo4jGraphFactory neo4JGraphFactory = new Neo4jGraphFactory();
+    private String database;
 
     public boolean connect(ConnectionParameter connectionParameter) {
         try {
@@ -28,6 +24,7 @@ public class Neo4jClient {
                             connectionParameter.getPasswordAsString()
                     )
             );
+            database = connectionParameter.getDatabase();
             driver.verifyConnectivity();
             return true;
         } catch (AuthenticationException | ServiceUnavailableException e) {
@@ -36,8 +33,12 @@ public class Neo4jClient {
         }
     }
 
+    private Session getSession(){
+        return driver.session(SessionConfig.builder().withDatabase(database).build());
+    }
+
     public void executeQuery(CypherQuery cypherQuery) throws Neo4jClientException {
-        try (Session session = driver.session()) {
+        try (Session session = getSession()) {
             session.run(cypherQuery.getQuery(), cypherQuery.getParams());
         } catch (Exception e) {
             throw new Neo4jClientException(e.getMessage(), e);
@@ -45,7 +46,7 @@ public class Neo4jClient {
     }
 
     public Graph getGraph(CypherQuery cypherQuery) throws Neo4jClientException {
-        try (Session session = driver.session()) {
+        try (Session session = getSession()) {
             Result statementResult = session.run(cypherQuery.getQuery(), cypherQuery.getParams());
             return Graph.createFrom(statementResult.list(neo4JGraphFactory::create));
         } catch (Exception e) {
@@ -54,7 +55,7 @@ public class Neo4jClient {
     }
 
     public List<Record> getResults(CypherQuery cypherQuery) throws Neo4jClientException {
-        try (Session session = driver.session()) {
+        try (Session session = getSession()) {
             Result statementResult = session.run(cypherQuery.getQuery(), cypherQuery.getParams());
             return statementResult.list();
         } catch (Exception e) {
@@ -64,7 +65,7 @@ public class Neo4jClient {
 
 
     public void explainQuery(CypherQuery cypherQuery) throws Neo4jClientException {
-        try (Session session = driver.session()) {
+        try (Session session = getSession()) {
             session.run(cypherQuery.getExplainQuery(), cypherQuery.getParams());
         } catch (Exception e) {
             throw new Neo4jClientException(e.getMessage(), e);
@@ -72,7 +73,7 @@ public class Neo4jClient {
     }
 
     public boolean isConnected() {
-        return driver != null && driver.session().isOpen();
+        return driver != null && getSession().isOpen();
     }
 
     public void close() {

--- a/src/main/java/nl/corwur/cytoscape/neo4j/internal/ui/connect/ConnectDialog.java
+++ b/src/main/java/nl/corwur/cytoscape/neo4j/internal/ui/connect/ConnectDialog.java
@@ -13,15 +13,17 @@ class ConnectDialog extends JDialog { //NOSONAR , hierarchy level > 5
     private static final String OK_CMD = "ok";
     private JTextField usernameField = new JTextField("neo4j");
     private JTextField hostnameField = new JTextField("localhost");
+    private JTextField databaseField = new JTextField("database");
     private JPasswordField password = new JPasswordField();
     private boolean ok = false;
     private final transient Predicate<ConnectionParameter> connectionCheck;
 
-    ConnectDialog(JFrame jFrame, Predicate<ConnectionParameter> connectionCheck, String hostname, String username) {
+    ConnectDialog(JFrame jFrame, Predicate<ConnectionParameter> connectionCheck, String hostname, String username, String database) {
         super(jFrame);
         this.connectionCheck = connectionCheck;
         usernameField.setText(username);
         hostnameField.setText(hostname);
+        databaseField.setText(database);
     }
 
     void showConnectDialog() {
@@ -31,7 +33,7 @@ class ConnectDialog extends JDialog { //NOSONAR , hierarchy level > 5
         setModal(true);
         setResizable(true);
         pack();
-        setSize(380, 200);
+        setSize(380, 240);
         setVisible(true);
     }
 
@@ -47,8 +49,12 @@ class ConnectDialog extends JDialog { //NOSONAR , hierarchy level > 5
         usernameField.setText(username);
     }
 
+    void setDatabaseField(String database){
+        databaseField.setText(database);
+    }
+
     private ConnectionParameter getParameters() {
-        return new ConnectionParameter(hostnameField.getText(), usernameField.getText(), password.getPassword());
+        return new ConnectionParameter(hostnameField.getText(), usernameField.getText(), password.getPassword(), databaseField.getText());
     }
 
     private void init() {
@@ -57,7 +63,6 @@ class ConnectDialog extends JDialog { //NOSONAR , hierarchy level > 5
 
         JPanel topPanel = new JPanel(new GridBagLayout());
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-
 
         JButton okButton = new JButton("Connect");
         okButton.addActionListener(e -> ok());
@@ -68,6 +73,7 @@ class ConnectDialog extends JDialog { //NOSONAR , hierarchy level > 5
         cancelButton.setActionCommand(CANCEL_CMD);
 
         JLabel hostnameLabel = new JLabel("Hostname");
+        JLabel databaseLabel = new JLabel("Database");
         JLabel usernameLabel = new JLabel("Username");
         JLabel passwordLabel = new JLabel("Password");
         password = new JPasswordField();
@@ -77,6 +83,8 @@ class ConnectDialog extends JDialog { //NOSONAR , hierarchy level > 5
 
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.insets = new Insets(4, 4, 4, 4);
+
+        //Hostname
         gbc.gridx = 0;
         gbc.gridy = 0;
         gbc.weightx = 0;
@@ -88,26 +96,41 @@ class ConnectDialog extends JDialog { //NOSONAR , hierarchy level > 5
         gbc.weightx = 1;
         topPanel.add(hostnameField, gbc);
 
+        //Database name
         gbc.gridx = 0;
         gbc.gridy = 1;
         gbc.fill = GridBagConstraints.NONE;
         gbc.weightx = 0;
-        topPanel.add(usernameLabel, gbc);
+        topPanel.add(databaseLabel, gbc);
 
         gbc.gridx = 1;
         gbc.gridy = 1;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 0;
-        topPanel.add(usernameField, gbc);
+        topPanel.add(databaseField, gbc);
 
+        //Username
         gbc.gridx = 0;
         gbc.gridy = 2;
+        gbc.fill = GridBagConstraints.NONE;
+        gbc.weightx = 0;
+        topPanel.add(usernameLabel, gbc);
+
+        gbc.gridx = 1;
+        gbc.gridy = 2;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.weightx = 0;
+        topPanel.add(usernameField, gbc);
+
+        //Password
+        gbc.gridx = 0;
+        gbc.gridy = 3;
         gbc.fill = GridBagConstraints.NONE;
         gbc.weightx = 0;
         topPanel.add(passwordLabel, gbc);
 
         gbc.gridx = 1;
-        gbc.gridy = 2;
+        gbc.gridy = 3;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 0;
         topPanel.add(password, gbc);
@@ -128,7 +151,7 @@ class ConnectDialog extends JDialog { //NOSONAR , hierarchy level > 5
     }
 
     public static void main(String[] args) {
-        ConnectDialog connectDialog = new ConnectDialog(null, connectionParameter -> true, "localhost", "neo4j");
+        ConnectDialog connectDialog = new ConnectDialog(null, connectionParameter -> true, "localhost", "neo4j", "neo4j");
         connectDialog.showConnectDialog();
 
     }
@@ -141,4 +164,7 @@ class ConnectDialog extends JDialog { //NOSONAR , hierarchy level > 5
         return usernameField.getText();
     }
 
+    public String getDatabase() {
+        return databaseField.getText();
+    }
 }

--- a/src/main/java/nl/corwur/cytoscape/neo4j/internal/ui/connect/ConnectToNeo4j.java
+++ b/src/main/java/nl/corwur/cytoscape/neo4j/internal/ui/connect/ConnectToNeo4j.java
@@ -37,11 +37,12 @@ public class ConnectToNeo4j {
     public boolean connect() {
         ConnectDialog connectDialog = new ConnectDialog(cySwingApplication.getJFrame(), neo4jClient::connect,
                 appConfiguration.getNeo4jHost(),
-                appConfiguration.getNeo4jUsername()
+                appConfiguration.getNeo4jUsername(),
+                appConfiguration.getNeo4jDatabase()
         );
         connectDialog.showConnectDialog();
         if (connectDialog.isOk()) {
-            appConfiguration.setConnectionParameters(connectDialog.getHostname(), connectDialog.getUsername());
+            appConfiguration.setConnectionParameters(connectDialog.getHostname(), connectDialog.getUsername(), connectDialog.getDatabase());
             appConfiguration.save();
             JOptionPane.showMessageDialog(this.cySwingApplication.getJFrame(), "Connected");
         }


### PR DESCRIPTION
## Why

Neo4j 4.x introduced multiple tenancy, which allows a _server_ to have multiple _database_ instances in it. The `0.4` version of CytoscapeNeo4j can only connect to the default `neo4j` _database_ on a given _server_.

## What this PR does 

This PR allows you to globally set the _database_ on the _Connect_ UI. This _database_ will be used throughout the session, and is saved with the connection. 

The Connection UI has been updated to allow a user to supply a `database` field that is then used for all subsequent querying.

Changing the connection to point to another _database_ will mean any queries run would be against that database. The database is _not_ on a per-query basis in this PR.

## Other Changes

* Bumped the Neo4j Driver version to the most recent one (`4.4.1`)
* Increased version number to `0.5`
* Changed the connection scheme to `neo4j://` (from `bolt://`) - this allows for connecting to a Cluster environment as well as a single instance.
