### PR TITLE
Bump log4j version to clear log4shell vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <org.osgi.core.version>6.0.0</org.osgi.core.version>
         <neo4j-java-driver.version>4.4.1</neo4j-java-driver.version>
         <junit.version>4.13.1</junit.version>
-        <log4j.version>1.2.17</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <maven-bundle-plugin.version>4.2.1</maven-bundle-plugin.version>
         <mockito-core.version>3.3.3</mockito-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <org.osgi.core.version>6.0.0</org.osgi.core.version>
         <neo4j-java-driver.version>4.4.1</neo4j-java-driver.version>
         <junit.version>4.13.1</junit.version>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <maven-bundle-plugin.version>4.2.1</maven-bundle-plugin.version>
         <mockito-core.version>3.3.3</mockito-core.version>


### PR DESCRIPTION
Please consider this PR as soon as possible and upload a new version or your app to the Cytoscape App Store (https://apps.cytoscape.org/apps/cytoscapeneo4jplugin).

See https://logging.apache.org/log4j/2.x/manual/migration.html